### PR TITLE
Add limit for issue references

### DIFF
--- a/TabletBot.Common/Settings.cs
+++ b/TabletBot.Common/Settings.cs
@@ -23,6 +23,8 @@ namespace TabletBot.Common
         public string DiscordBotToken { set; get; } = null;
         public string GitHubToken { set; get; } = null;
         public string CommandPrefix { set; get; } = "!";
+        public uint GitHubIssueRefLimit { set; get; } = 3;
+
         public LogLevel LogLevel { set; get; } = LogLevel.Debug;
 
         public Collection<RoleManagementMessageStore> ReactiveRoles { set; get; } = new Collection<RoleManagementMessageStore>();

--- a/TabletBot.Discord/Bot.cs
+++ b/TabletBot.Discord/Bot.cs
@@ -99,8 +99,12 @@ namespace TabletBot.Discord
         {
             if (GitHubTools.TryGetIssueRefNumbers(message.Content, out var refs))
             {
+                uint refNum = 0;
                 foreach (int issueRef in refs)
                 {
+                    if (refNum == Settings.Current.GitHubIssueRefLimit)
+                        break;
+
                     var issues = await GitHubAPI.Current.Issue.GetAllForRepository("InfinityGhost", "OpenTabletDriver");
                     var prs = await GitHubAPI.Current.PullRequest.GetAllForRepository("InfinityGhost", "OpenTabletDriver");
                     if (issues.FirstOrDefault(i => i.Number == issueRef) is Issue issue)
@@ -109,6 +113,7 @@ namespace TabletBot.Discord
                         var embed = pr == null ? GitHubEmbeds.GetIssueEmbed(issue) : GitHubEmbeds.GetPullRequestEmbed(pr);
                         await message.Channel.SendMessageAsync(embed: embed);
                     }
+                    refNum++;
                 }
             }
         }


### PR DESCRIPTION
Fixes the oversight that a single user can spam a channel quickly by referencing a ton of issues. This can also cause rate limiting on the GitHub API itself if not monitored correctly. This is only a workaround and not a definite fix for the issue, and likely could still be done if a user was maliciously attempting to spam a channel.