### PR TITLE
Trim base indentation off code block content

### DIFF
--- a/TabletBot.Discord/Formatting.cs
+++ b/TabletBot.Discord/Formatting.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text;
 using Discord;
 
@@ -22,10 +23,31 @@ namespace TabletBot.Discord
 
         public static void AppendCodeBlock(this StringBuilder stringBuilder, string[] lines, string? lang = null)
         {
+            TrimBaseIndentation(lines);
+
             stringBuilder.AppendLine(CODE_BLOCK + lang);
             foreach (var line in lines)
                 stringBuilder.AppendLine(line);
             stringBuilder.AppendLine(CODE_BLOCK);
+        }
+
+        public static void TrimBaseIndentation(string[] lines)
+        {
+            var baseIndentationLength = lines.Min(line => {
+                var indentation = CountIndentation(line);
+                return line.Length > indentation ? indentation : int.MaxValue;
+            });
+
+            for (int i = 0; i != lines.Length; i++)
+                lines[i] = lines[i].Substring(Math.Min(baseIndentationLength, lines[i].Length)).TrimEnd();
+        }
+
+        public static int CountIndentation(string line)
+        {
+            for (var i = 0; i < line.Length; i++)
+                if (!char.IsWhiteSpace(line[i]))
+                    return i;
+            return int.MaxValue;
         }
     }
 }


### PR DESCRIPTION
## Changes

- Trim code block indentation within `Formatting` extension

Have not tested live.

As opposed to my other PR (https://github.com/OpenTabletDriver/OpenTabletDriver.Web/pull/92) which only considered the first line's indentation, this implementation takes the minimum indentation length among all non-blank lines as its baseline.

I think both implementations are okay within their own contexts. With Markdown/HTML it doesn't make much sense to have invalid indentation anyway, but with TabletBot it's a lot more likely to occur as it works with user provided line ranges.